### PR TITLE
:sparkles: add environment validation with Zod (#52)

### DIFF
--- a/app/lib/env.ts
+++ b/app/lib/env.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+import tryParseEnv from "./try-parse-env";
+
+const EnvSchema = z.object({
+  NODE_ENV: z.string(),
+});
+
+export type EnvSchema = z.infer<typeof EnvSchema>;
+
+tryParseEnv(EnvSchema);
+
+// eslint-disable-next-line node/no-process-env
+export default EnvSchema.parse(process.env);

--- a/app/lib/try-parse-env.ts
+++ b/app/lib/try-parse-env.ts
@@ -1,0 +1,27 @@
+/* eslint-disable node/no-process-env */
+import type { ZodObject, ZodRawShape } from "zod";
+
+import { ZodError } from "zod";
+
+export default function tryParseEnv<T extends ZodRawShape>(
+  EnvSchema: ZodObject<T>,
+  buildEnv: Record<string, string | undefined> = process.env,
+) {
+  try {
+    EnvSchema.parse(buildEnv);
+  }
+  catch (error) {
+    if (error instanceof ZodError) {
+      let message = "Missing required values in .env:\n";
+      error.issues.forEach((issue) => {
+        message += `${issue.path[0]}\n`;
+      });
+      const e = new Error(message);
+      e.stack = "";
+      throw e;
+    }
+    else {
+      console.error(error);
+    }
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,7 @@
 import tailwindcss from "@tailwindcss/vite";
 
+import "./app/lib/env";
+
 export default defineNuxtConfig({
   compatibilityDate: "2025-07-15",
   devtools: { enabled: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "nuxt": "^4.0.0",
         "tailwindcss": "^4.1.11",
         "vue": "^3.5.17",
-        "vue-router": "^4.5.1"
+        "vue-router": "^4.5.1",
+        "zod": "^4.0.5"
       },
       "devDependencies": {
         "@antfu/eslint-config": "^4.17.0",
@@ -2427,6 +2428,15 @@
         "@esbuild/win32-arm64": "0.25.5",
         "@esbuild/win32-ia32": "0.25.5",
         "@esbuild/win32-x64": "0.25.5"
+      }
+    },
+    "node_modules/@netlify/zip-it-and-ship-it/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -17189,9 +17199,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
+      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "nuxt": "^4.0.0",
     "tailwindcss": "^4.1.11",
     "vue": "^3.5.17",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.17.0",


### PR DESCRIPTION
- Introduced `try-parse-env` utility for environment variable validation.
- Created `EnvSchema` for defining required environment variables.
- Installed `zod` as a dependency.
- Integrated environment validation in `nuxt.config.ts`.

closes #13