### PR TITLE
Improve auth store initialization and middleware logic

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import NavBar from "~/components/app/nav-bar.vue";
+
+const authStore = useAuthStore();
+authStore.init();
 </script>
 
 <template>

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -3,9 +3,13 @@ import { defineStore } from "pinia";
 
 const authClient = createAuthClient();
 export const useAuthStore = defineStore("useAuthStore", () => {
-  const session = authClient.useSession();
-  const user = computed(() => session.value.data?.user);
-  const loading = computed(() => session.value.isPending || session.value.isRefetching);
+  const session = ref<Awaited<ReturnType<typeof authClient.useSession>> | null>(null);
+  async function init() {
+    session.value = await authClient.useSession(useFetch);
+  }
+
+  const user = computed(() => session.value?.data?.user);
+  const loading = computed(() => session.value?.isPending);
 
   async function signIn() {
     await authClient.signIn.social({
@@ -21,6 +25,7 @@ export const useAuthStore = defineStore("useAuthStore", () => {
   }
 
   return {
+    init,
     loading,
     signIn,
     signOut,

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -5,7 +5,7 @@ export default defineEventHandler(async (event) => {
     const session = await auth.api.getSession({
       headers: event.headers,
     });
-    if (!session) {
+    if (!session?.user) {
       await sendRedirect(event, "/", 302);
     }
   }


### PR DESCRIPTION
- Refactored `auth.ts` store to introduce an `init` method for session handling.
- Updated default layout to call `authStore.init` on load.
- Enhanced auth middleware to check for `session.user` instead of `session`.

closes #20